### PR TITLE
Test Python 3.12 pre-release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test suite
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", pypy-3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", pypy-3.9]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
         cache-dependency-path: pyproject.toml
     - name: Start external services

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test suite
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: test suite
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: test suite
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ pretty = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{py3, 38, 39, 310, 311, 312}
+envlist = pypy3, py38, py39, py310, py311, py312
 skip_missing_interpreters = true
 minversion = 4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ pretty = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = pypy3, py38, py39, py310, py311
+envlist = py{py3, 38, 39, 310, 311, 312}
 skip_missing_interpreters = true
 minversion = 4.0
 


### PR DESCRIPTION
Python 3.12 is in beta in a couple of weeks, so it's a good time to start testing to make sure everything is ready for the 3.12.0 release in October.

* https://peps.python.org/pep-0693/

I didn't add the 3.12 classifier; some prefer to wait until 3.12.0 is out, some have [already](https://pypi.org/search/?q=&o=-created&c=Programming+Language+%3A%3A+Python+%3A%3A+3.12) [added it](https://pyreadiness.org/3.12/).

---

Also:

* Allow testing feature branches on the CI to uninhibit contribution
* Allow triggering builds via the GitHub UI (`workflow_dispatch`)
* Add colour to logs for readability
